### PR TITLE
Add quotes to HeidiSQ host parameter and remove double quoting from args

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -7,15 +7,15 @@
 ## OSTypes: windows,wsl2
 ## HostBinaryExists: /mnt/c/Program Files/HeidiSQL/heidisql.exe,C:\Program Files\HeidiSQL\Heidisql.exe
 
-arguments="--host=127.0.0.1 --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
+arguments="--host=\"127.0.0.1\" --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
 
 case $OSTYPE in
   "win*"* | "msys"*)
-    '/c/Program Files/HeidiSQL/heidisql.exe' "$arguments" &
+    '/c/Program Files/HeidiSQL/heidisql.exe' $arguments &
     ;;
   # linux-gnu in this case is only WSL2 as selected in OSTypes above
   "linux-gnu")
     # HeidiSQL is Microsoft only, but we want to start it from WSL2
-    "/mnt/c/Program Files/HeidiSQL/heidisql.exe" "$arguments" &
+    "/mnt/c/Program Files/HeidiSQL/heidisql.exe" $arguments &
     ;;
 esac


### PR DESCRIPTION

## The Issue

When launching HeidiSQL via "ddev heidisql" there is an additional double quote at the end of each database connection name. If you remove the double quotes from the arguments the host parameter must be written in double quotes as the documentation suggests it (Docu: https://www.heidisql.com/help.php#commandline).

## How This PR Solves The Issue

This PR removes the double quotes at the end of the string and adds them to the host parameter.

## Manual Testing Instructions

Run `dddev heidisql` to start the programm from WSL2 with correct parameters.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

